### PR TITLE
Bump postgres from 9.5 to 13.2 in /deploy

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,1 +1,1 @@
-FROM postgres:9.5
+FROM postgres:13.2


### PR DESCRIPTION
Bumps postgres from 9.5 to 13.2.
