### PR TITLE
Bump postgres from 9.5 to 13.2 in /docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,3 @@
-FROM postgres:9.5
+FROM postgres:13.2
 
-FROM postgres:10.16
+FROM postgres:13.2


### PR DESCRIPTION
Bumps postgres from 9.5 to 13.2.
